### PR TITLE
Add $domain variable

### DIFF
--- a/SCOMDecrypt/Invoke-SCOMDecrypt.ps1
+++ b/SCOMDecrypt/Invoke-SCOMDecrypt.ps1
@@ -69,6 +69,7 @@ function Invoke-SCOMDecrypt
 		if ($dataset.Tables[0].Rows[$i].Data -ne [System.DBNull]::Value -and $dataset.Tables[0].Rows[$i].Username -ne [System.DBNull]::Value)
 		{
 			$user = $dataset.Tables[0].Rows[$i].Username
+			$domain = $dataset.Tables[0].Rows[$i].Domain
 			$passw = [System.Text.Encoding]::UTF8.GetString($scom.Decrypt($dataset.Tables[0].Rows[$i].Data))
 			
 			# Cleans up the spaces in the password


### PR DESCRIPTION
I know this is old, but I used this script today and noticed that the $domain variable is not defined, so it triggers the else clause and just prints user and pass instead of domain\user.